### PR TITLE
Fixed bug #74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Atom-path-Intellisense
 ## CHANGELOG :barber:
 
+### 1.2.2
+- Fixed bug [#74 configs disappear](https://github.com/apercova/atom-path-intellisense/issues/74)  
+
 ### 1.2.1
 - Improved matching algorithm for Node.js provider, included multiline ES6 import statements.
 - Included `.source.ts` and `.source.coffee` grammar selectors on Node.js provider.

--- a/lib/atom-path-intellisense.js
+++ b/lib/atom-path-intellisense.js
@@ -18,7 +18,9 @@ class AtomPathIntellisense {
   /**
    * @return {AtomPathIntellisense}  AtomPathIntellisense instance.
    */
-  constructor() {}
+  constructor() {
+    this.config = settings;
+  }
 
   /**
    * getProvider - Retrieves autocomplete-plus provider.
@@ -36,7 +38,6 @@ class AtomPathIntellisense {
    */
   initialize() {
     this._logger = logger.getLogger('AtomPathIntellisense');
-    this.config = settings;
   }
 
   /**


### PR DESCRIPTION
Fixed bug #74 configs disappear at https://github.com/apercova/atom-path-intellisense/issues/74